### PR TITLE
Quoting buildpath / globstars

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "webpack-watch": "set NODE_ENV=0&& webpack --progress --color --watch --hot",
     "dev:sass": "node-sass -w -r src/css/ -o src/public/assets/css/",
     "dev:js": "set NODE_ENV=0&& webpack",
-    "build:dir": "copyfiles -u 1 src/public/**/* build/",
+    "build:dir": "copyfiles -u 1 'src/public/**/*' build/",
     "build:sass": "node-sass --output-style compressed src/css/ -o build/public/assets/css/",
     "build:js": "set NODE_ENV=1&& webpack --progress --color"
   },


### PR DESCRIPTION
**Problem I ran into:**
`npm run build` only created the 

> build/public/assets/css/app.css

 file, nothing else was copied.
No Error showed up in Terminal. Operating system is CentOS.

**Solution:**
After reading the `copyfiles`-module readme I discovered you may have to put the path in quotation marks. Doing so fixed it and copied the whole public folders like its supposed to.
https://github.com/calvinmetcalf/copyfiles#command-line