### PR TITLE
move plugins declaration below production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,14 +16,7 @@ var env = 'dev',
     time = Date.now(),
     devtool = 'eval',
     mode = 'development',
-    stats = 'minimal',
-    plugins = [
-      //new webpack.NoErrorsPlugin(),
-      new webpack.DefinePlugin({
-        __ENV__: JSON.stringify(env),
-        ___BUILD_TIME___: time
-      })
-    ];
+    stats = 'minimal';
 
 // Production environment
 if(PROD) {
@@ -33,6 +26,14 @@ if(PROD) {
   stats = 'none';
   outputPath = __dirname + '/build/public/assets/js';
 }
+
+var plugins = [
+  //new webpack.NoErrorsPlugin(),
+  new webpack.DefinePlugin({
+    __ENV__: JSON.stringify(env),
+    ___BUILD_TIME___: time
+  })
+];
 
 console.log('Webpack build - ENV: ' + env + ' V: ' + time);
 console.log('    - outputPath ', outputPath);


### PR DESCRIPTION
The current version is working fine on CentOS, but running a production build on Windows10 I encountered the following problem:
the `webpack.DefinePlugin()` replaces `__ENV__` before the `env = "prod";` is executed. Resulting in a production build, but the global var is still set to "dev".

I was pulling my hair out before and while encountering this :rage1: Can someone confirm this?