### PR TITLE
Fixed publicPath for dev server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,8 @@ module.exports = env => {
       // must be an absolute path (use the Node.js path module)
       path: outputPath,
       // the url to the output directory resolved relative to the HTML page
-      publicPath: 'js',
+      // should include at least trailing slash
+      publicPath: '/js/',
       // the filename template for entry chunks
       filename: '[name].bundle.js',
       chunkFilename: '[name].bundle.js',


### PR DESCRIPTION
Added trailing slash to publicPath so that dev server resolves to in-memory resources, more info here https://webpack.js.org/configuration/output/#outputpublicpath

Resolves issue https://github.com/paulmg/ThreeJS-Webpack-ES6-Boilerplate/issues/38